### PR TITLE
Update Versions for Cast, Sift, Remnux -- Added || true to skip failed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL version="5.0"
-LABEL description="SIFT and REMnux Docker based on Ubuntu 20.04 LTS"
+LABEL description="SIFT and REMnux Docker based on Ubuntu 22.04 LTS"
 LABEL maintainer="https://github.com/digitalsleuth/sift-remnux"
-ARG CAST=0.14.0
-ARG REMNUX_VERSION=v2023.9.1
-ARG SIFT_VERSION=v2023.02.06
+ARG CAST=0.14.50
+ARG REMNUX_VERSION=v2024.41.4
+ARG SIFT_VERSION=v2023.02.29
 ARG FOR_USER=forensics
 ARG DESCR="Forensics User"
 ARG PASS="forensics"
 
-ENV TERM linux
+ENV TERM=linux
 
 USER root
 WORKDIR /tmp
@@ -24,12 +24,18 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     chown -R ${FOR_USER}:${FOR_USER} /home/${FOR_USER} && \
     usermod -a -G sudo ${FOR_USER} && \
     echo "${FOR_USER}:${PASS}" | chpasswd && \
-    wget https://github.com/ekristen/cast/releases/download/v${CAST}/cast_v${CAST}_linux_amd64.deb && \
-    dpkg -i /tmp/cast_v${CAST}_linux_amd64.deb && \
-    rm /tmp/cast_v${CAST}_linux_amd64.deb
+    wget https://github.com/ekristen/cast/releases/download/v${CAST}/cast-v${CAST}-linux-amd64.deb && \
+    dpkg -i /tmp/cast-v${CAST}-linux-amd64.deb && \
+    rm /tmp/cast-v${CAST}-linux-amd64.deb
 
-RUN cast install --mode server --user ${FOR_USER} sift && \
-    cast install --mode cloud --user ${FOR_USER} remnux
+RUN cast install --mode server --user ${FOR_USER} teamdfir/sift-saltstack  || true
+
+RUN cast install --mode addon --user ${FOR_USER} remnux/salt-states  || true
+
+RUN git clone https://github.com/volatilityfoundation/volatility3.git /opt/volatility3 && \
+    cd /opt/volatility3 && \
+    python3 setup.py install && \
+    chown -R ${FOR_USER}:${FOR_USER} /opt/volatility3
 
 RUN git clone https://github.com/digitalsleuth/color_ssh_terminal /tmp/colorssh && \
     cd /tmp/colorssh && cat color_ssh_terminal >> /home/${FOR_USER}/.bashrc && cd /tmp && rm -rf colorssh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 LABEL version="5.0"
 LABEL description="SIFT and REMnux Docker based on Ubuntu 22.04 LTS"
@@ -28,9 +28,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     dpkg -i /tmp/cast-v${CAST}-linux-amd64.deb && \
     rm /tmp/cast-v${CAST}-linux-amd64.deb
 
-RUN cast install --mode server --user ${FOR_USER} teamdfir/sift-saltstack  || true
+RUN cast install --mode server --user ${FOR_USER} teamdfir/sift-saltstack
 
-RUN cast install --mode addon --user ${FOR_USER} remnux/salt-states  || true
+RUN cast install --mode cloud --user ${FOR_USER} remnux/salt-states
 
 RUN git clone https://github.com/volatilityfoundation/volatility3.git /opt/volatility3 && \
     cd /opt/volatility3 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     dpkg -i /tmp/cast-v${CAST}-linux-amd64.deb && \
     rm /tmp/cast-v${CAST}-linux-amd64.deb
 
-RUN cast install --mode server --user ${FOR_USER} teamdfir/sift-saltstack
+RUN cast install --mode server --user ${FOR_USER} teamdfir/sift-saltstack || true
 
-RUN cast install --mode cloud --user ${FOR_USER} remnux/salt-states
+RUN cast install --mode cloud --user ${FOR_USER} remnux/salt-states || true
 
 RUN git clone https://github.com/volatilityfoundation/volatility3.git /opt/volatility3 && \
     cd /opt/volatility3 && \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# **SIFT-REMnux**  ![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/digitalsleuth/sift-remnux)
-SIFT and REMnux Docker based on Ubuntu 22.04 LTS
-
-Added a docker-compose.yaml to the repo containing the commands required to get the most of the docker.
+# **SIFT-REMnux**
+SIFT and REMnux Docker based on Ubuntu 20.04 LTS 
+~~22.04 LTS Does have some fails and would require `|| true` to skip failed programs~~
 
 ## **Build Docker**
 
-1. **To build the docker using the dockerfile, run the following commands:**
+**To build the docker using the dockerfile, run the following commands:**
 
 ```bash
 ## Clone the repo
@@ -25,12 +24,12 @@ docker run -d -p 33:22 sift-remnux
 ssh -X forensics@$(hostname -I | awk '{print $1}') -p 33
 
 ```
-2. **You can also interact with the docker using the following command:**
+**You can also interact with the docker using the following command:**
 ```bash
 docker exec -it sift-remnux /bin/bash
 ```
 
-3. **If you need or want access to a mapped folder, you can use the following command:**
+**If you need or want access to a mapped folder, you can use the following command:**
 ```bash
 mkdir {pwd}/files
 
@@ -39,7 +38,7 @@ docker run -d -p 33:22 -v {pwd}/files:/home/forensics sift-remnux
 
 ## **Running in Docker-Compose**
 
-4. **To run the docker in docker-compose, use the following commands:**
+**To run the docker in docker-compose, use the following commands:**
 
 ```bash
 ## Clone the repo

--- a/README.md
+++ b/README.md
@@ -1,8 +1,57 @@
-# SIFT-REMnux  ![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/digitalsleuth/sift-remnux)
-SIFT and REMnux Docker based on Ubuntu 20.04 LTS
+# **SIFT-REMnux**  ![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/digitalsleuth/sift-remnux)
+SIFT and REMnux Docker based on Ubuntu 22.04 LTS
 
 Added a docker-compose.yaml to the repo containing the commands required to get the most of the docker.
 
-Once started, run the following: `ssh -X forensics@<ip>` where `<ip>` is the IP of the docker you identify in the docker-compose.yaml file. 
-  
+## **Build Docker**
+
+1. **To build the docker using the dockerfile, run the following commands:**
+
+```bash
+## Clone the repo
+git clone https://github.com/digitalsleuth/sift-remnux.git
+
+## Change to the directory
+cd sift-remnux
+
+## Build the docker
+docker build -t sift-remnux .
+
+## Run the docker (Port 33 is your SSH port)
+docker run -d -p 33:22 sift-remnux
+
+## SSH into the docker
+#ssh -X forensics@localhost -p 33
+ssh -X forensics@$(hostname -I | awk '{print $1}') -p 33
+
+```
+2. **You can also interact with the docker using the following command:**
+```bash
+docker exec -it sift-remnux /bin/bash
+```
+
+3. **If you need or want access to a mapped folder, you can use the following command:**
+```bash
+mkdir {pwd}/files
+
+docker run -d -p 33:22 -v {pwd}/files:/home/forensics sift-remnux
+```
+
+## **Running in Docker-Compose**
+
+4. **To run the docker in docker-compose, use the following commands:**
+
+```bash
+## Clone the repo
+git clone https://github.com/digitalsleuth/sift-remnux.git
+
+## Change to the directory
+cd sift-remnux
+
+## Run the docker-compose
+docker-compose up -d
+```
+
+I reccomend using SSH using the MOBAXTERM or another SSH client that supports X11 forwarding.
+
 This will provide GUI functionality from within the docker.


### PR DESCRIPTION
1. Updated Versions
    - Cast 14.50
    - Sift
    - Remnux
2.  Added = to TERM
3.  Fixed/Changed URL Hyphens for cast
4.  Added Install for Vol3
5.  Updated Readme.
6.  Separated and added `|| True` due to minor errors on installs. - Likely from the update. 

5x Errors on Sift
```
1679.9 time="2024-10-15T07:29:47Z" level=warning msg="first failed state" comment="Failed to install packages: defang==0.5.2. Error: Collecting defang==0.5.2 Downloading defang-0.5.2.tar.gz (4.4 kB) /usr/lib/python3/dist-packages/secretstorage/dhcrypto.py:15: CryptographyDeprecationWarning: int_from_bytes is deprecated, use int.from_bytes instead from cryptography.utils import int_from_bytes /usr/lib/python3/dist-packages/secretstorage/util.py:19: CryptographyDeprecationWarning: int_from_bytes is deprecated, use int.from_bytes instead from cryptography.utils import int_from_bytes ERROR: Command errored out with exit status 1: command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '\\'\\'/tmp/pip-install-44_aqeln/defang_48a30095da974c7cbd7a28902f072bb1/setup.py'\\'\\'; __file__='\\'\\'/tmp/pip-install-44_aqeln/defang_48a30095da974c7cbd7a28902f072bb1/setup.py'\\'\\';f=getattr(tokenize, '\\'\\'open'\\'\\', open)(__file__);code=f.read().replace('\\'\\'\\\\r\\\\n'\\'\\', '\\'\\'\\\\n'\\'\\');f.close();exec(compile(code, __file__, '\\'\\'exec'\\'\\'))' egg_info --egg-base /tmp/pip-pip-egg-info-d0qn18wo cwd: /tmp/pip-install-44_aqeln/defang_48a30095da974c7cbd7a28902f072bb1/ Complete output (9 lines): Traceback (most recent call last): File \\<string>\\, line 1, in <module> File \\/usr/local/lib/python3.8/dist-packages/setuptools/__init__.py\\, line 27, in <module> from .dist import Distribution File \\/usr/local/lib/python3.8/dist-packages/setuptools/dist.py\\, line 18, in <module> from . import ( File \\/usr/local/lib/python3.8/dist-packages/setuptools/_entry_points.py\\, line 45, in <module> def validate(eps: metadata.EntryPoints): AttributeError: module 'importlib_metadata' has no attribute 'EntryPoints' ---------------------------------------- WARNING: Discarding https://files.pythonhosted.org/packages/d9/c9/faa3b40c3c3f770d1c1fd98a75bf7b76ef03055809d57dae559835e8aa4c/defang-0.5.2.tar.gz#sha256=a937ebb8313bbbce0466653ed47221cfb5be65d06189d5ab2f99f4e3e305baa4 (from https://pypi.org/simple/defang/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output. ERROR: Could not find a version that satisfies the requirement defang==0.5.2 ERROR: No matching distribution found for defang==0.5.2" component=installer run_num=300 sls=sift.python3-packages.defang

1679.9 time="2024-10-15T07:29:47Z" level=info msg=statistics component=installer failed=5 success=565 total=570
```